### PR TITLE
Fact optimizer

### DIFF
--- a/src/main/java/GeometryCore/ExpertSystem.java
+++ b/src/main/java/GeometryCore/ExpertSystem.java
@@ -6,6 +6,7 @@ public class ExpertSystem {
         //while (lastFactsAmount != model.facts.size()) {
             for (Rule rule : RuleStorage.getInstance().rules) {
                 rule.applyToModel(model);
+                FactOptimizer.deleteRepeatingFacts(model);
             }
         //}
     }

--- a/src/main/java/GeometryCore/FactOptimizer.java
+++ b/src/main/java/GeometryCore/FactOptimizer.java
@@ -1,0 +1,28 @@
+package GeometryCore;
+
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collector;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import GeometryCore.Facts.Fact;
+import GeometryCore.GeometryObjects.GeometryObject;
+
+public class FactOptimizer {
+    public static void deleteRepeatingFacts(Model model){
+        HashSet<Fact> newFacts = new HashSet<>(model.facts);
+        for (Fact fact: model.facts) {
+            if (!newFacts.contains(fact))
+                continue;
+
+            List<Fact> allSimilarFacts =  newFacts.stream().filter(x -> x!=fact&&
+                    x.getClass().equals(fact.getClass())&&
+                    fact.isTheSameFact(x)).collect(Collectors.toList());
+            newFacts.removeAll(allSimilarFacts);
+        }
+        model.facts=newFacts;
+    }
+}

--- a/src/main/java/GeometryCore/FactOptimizer.java
+++ b/src/main/java/GeometryCore/FactOptimizer.java
@@ -18,9 +18,12 @@ public class FactOptimizer {
             if (!newFacts.contains(fact))
                 continue;
 
-            List<Fact> allSimilarFacts =  newFacts.stream().filter(x -> x!=fact&&
+            List<Fact> allSimilarFacts =  newFacts.stream().filter
+                    (x -> x!=fact&&
                     x.getClass().equals(fact.getClass())&&
-                    fact.isTheSameFact(x)).collect(Collectors.toList());
+                    fact.isTheSameFact(x))
+                        .collect(Collectors.toList());
+
             newFacts.removeAll(allSimilarFacts);
         }
         model.facts=newFacts;

--- a/src/main/java/GeometryCore/Facts/Fact.java
+++ b/src/main/java/GeometryCore/Facts/Fact.java
@@ -4,8 +4,6 @@ import GeometryCore.GeometryObjects.GeometryObject;
 
 public abstract class Fact implements SubObjectsEditor<GeometryObject, Fact> {
     public boolean isTheSameFact(Fact fact){
-     //   if (!fact.getClass().equals(getClass()))
-     //       return false;
         return getAllSubObjects().containsAll(fact.getAllSubObjects());
     }
 

--- a/src/main/java/GeometryCore/Facts/Fact.java
+++ b/src/main/java/GeometryCore/Facts/Fact.java
@@ -3,5 +3,10 @@ import GeometryCore.SubObjectsEditor;
 import GeometryCore.GeometryObjects.GeometryObject;
 
 public abstract class Fact implements SubObjectsEditor<GeometryObject, Fact> {
+    public boolean isTheSameFact(Fact fact){
+     //   if (!fact.getClass().equals(getClass()))
+     //       return false;
+        return getAllSubObjects().containsAll(fact.getAllSubObjects());
+    }
 
 }

--- a/src/main/java/GeometryCore/GeometryObjects/Angle.java
+++ b/src/main/java/GeometryCore/GeometryObjects/Angle.java
@@ -6,7 +6,11 @@ import java.util.Map;
 public class Angle extends GeometryObject {
     public LinkedList<GeometryObject> geometryObjects;
 
+
     public Angle(LinkedList<GeometryObject> geometryObjects) {
+        if (geometryObjects.size() != 2){
+            throw new RuntimeException("Illegal constructor for angle");
+        }
         this.geometryObjects = geometryObjects;
     }
 

--- a/src/main/java/GeometryCore/GeometryObjects/GeometryObject.java
+++ b/src/main/java/GeometryCore/GeometryObjects/GeometryObject.java
@@ -1,8 +1,30 @@
 package GeometryCore.GeometryObjects;
 
+import java.util.LinkedList;
+
 import GeometryCore.SubObjectsEditor;
 
 public abstract class GeometryObject implements SubObjectsEditor<GeometryObject, GeometryObject>, Cloneable {
+    @Override
+    public boolean equals(Object o) {
+
+        //Same link
+        if (this == o)
+            return true;
+
+        if (!(o.getClass().equals(this.getClass())))
+            return false;
+
+        LinkedList<GeometryObject> ourSubObjects = this.getAllSubObjects();
+        LinkedList<GeometryObject> theirSubObjects=((GeometryObject)o).getAllSubObjects();
+
+
+        if (ourSubObjects.size() == 0 || ourSubObjects.size() != theirSubObjects.size()){
+            return false;
+        }
+        return theirSubObjects.containsAll(ourSubObjects);
+    }
+
     @Override
     public Object clone() throws CloneNotSupportedException {
         return super.clone();

--- a/src/main/java/GeometryCore/GeometryObjects/NumberEnveloper.java
+++ b/src/main/java/GeometryCore/GeometryObjects/NumberEnveloper.java
@@ -12,7 +12,7 @@ public class NumberEnveloper extends Factor{
 
     @Override
     public LinkedList<GeometryObject> getAllSubObjects() {
-        return null;
+        return new LinkedList<>();
     }
 
     @Override

--- a/src/main/java/GeometryCore/GeometryObjects/Plane.java
+++ b/src/main/java/GeometryCore/GeometryObjects/Plane.java
@@ -13,6 +13,6 @@ public class Plane extends GeometryObject {
 
     @Override
     public LinkedList<GeometryObject> getAllSubObjects() {
-        return null;
+        return new LinkedList<>();
     }
 }

--- a/src/main/java/GeometryCore/GeometryObjects/StraightLine.java
+++ b/src/main/java/GeometryCore/GeometryObjects/StraightLine.java
@@ -14,6 +14,6 @@ public class StraightLine extends GeometryObject {
 
     @Override
     public LinkedList<GeometryObject> getAllSubObjects() {
-        return null;
+        return new LinkedList<>();
     }
 }

--- a/src/main/java/GeometryCore/GeometryObjects/Triangle.java
+++ b/src/main/java/GeometryCore/GeometryObjects/Triangle.java
@@ -7,17 +7,11 @@ import java.util.Map;
 public class Triangle extends GeometryObject {
     public HashSet<LineSegment> lineSegments;
     public Triangle(HashSet<LineSegment> lineSegments) {
-        this.lineSegments = lineSegments;
-    }
-    @Override
-    public boolean equals(Object o) {
-        if (this == o)
-            return true;
-        if (!(o instanceof Triangle))
-            return false;
-        Triangle triangleUnderQuestion = (Triangle)o;
 
-        return triangleUnderQuestion.lineSegments.containsAll(lineSegments);
+        if (lineSegments.size() != 3){
+            throw new RuntimeException("Illegal constructor for triangle");
+        }
+        this.lineSegments = lineSegments;
     }
 
     @Override

--- a/src/main/java/GeometryCore/GeometryObjects/Triangle.java
+++ b/src/main/java/GeometryCore/GeometryObjects/Triangle.java
@@ -16,10 +16,6 @@ public class Triangle extends GeometryObject {
         if (!(o instanceof Triangle))
             return false;
         Triangle triangleUnderQuestion = (Triangle)o;
-       // for (LineSegment mySegment:lineSegments) {
-       //     if (triangleUnderQuestion.lineSegments.contains())
-      //  }
-
 
         return triangleUnderQuestion.lineSegments.containsAll(lineSegments);
     }

--- a/src/main/java/GeometryCore/GeometryObjects/Triangle.java
+++ b/src/main/java/GeometryCore/GeometryObjects/Triangle.java
@@ -9,6 +9,20 @@ public class Triangle extends GeometryObject {
     public Triangle(HashSet<LineSegment> lineSegments) {
         this.lineSegments = lineSegments;
     }
+    @Override
+    public boolean equals(Object o) {
+        if (this == o)
+            return true;
+        if (!(o instanceof Triangle))
+            return false;
+        Triangle triangleUnderQuestion = (Triangle)o;
+       // for (LineSegment mySegment:lineSegments) {
+       //     if (triangleUnderQuestion.lineSegments.contains())
+      //  }
+
+
+        return triangleUnderQuestion.lineSegments.containsAll(lineSegments);
+    }
 
     @Override
     public GeometryObject createNewSimilarObject(Map<GeometryObject, GeometryObject> correspondence) {

--- a/src/main/java/GeometryCore/GeometryObjects/Vertex.java
+++ b/src/main/java/GeometryCore/GeometryObjects/Vertex.java
@@ -9,7 +9,7 @@ public class Vertex extends GeometryObject {
 
     @Override
     public LinkedList<GeometryObject> getAllSubObjects() {
-        return null;
+        return new LinkedList<>();
     }
 
     @Override

--- a/src/main/java/GeometryCore/Rule.java
+++ b/src/main/java/GeometryCore/Rule.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import GeometryCore.Facts.Fact;
 import GeometryCore.GeometryObjects.GeometryObject;
@@ -75,7 +76,8 @@ public class Rule {
                     match = obj;
                 else
                     match = factsCorrespondence.get(obj);
-                if (match != null && !curFactObjects.contains(match)) {
+                GeometryObject finalMatch = match;
+                if (match != null && curFactObjects.stream().noneMatch(x -> x == finalMatch)) {
                     isFit = false;
                     break;
                 }

--- a/src/main/java/GeometryCore/RuleStorage.java
+++ b/src/main/java/GeometryCore/RuleStorage.java
@@ -58,7 +58,7 @@ public class RuleStorage {
         LineSegment AB = new LineSegment(A, B);
         LineSegment BC = new LineSegment(B, C);
         LineSegment AC = new LineSegment(A, C);
-        Angle ACB = new Angle(new LinkedList(Arrays.asList(A, B, C)));
+        Angle ACB = new Angle(new LinkedList(Arrays.asList(AC, BC)));
         Triangle triangle = new Triangle(new HashSet<>(Arrays.asList(AB, AC, BC)));
         LinkedList<Fact> facts = new LinkedList<>();
         facts.add(new ExistFact(triangle));

--- a/src/test/java/ExpertSystemTest.java
+++ b/src/test/java/ExpertSystemTest.java
@@ -77,12 +77,12 @@ public class ExpertSystemTest{
         LineSegment AB = new LineSegment(A, B);
         LineSegment BC = new LineSegment(B, C);
         LineSegment AC = new LineSegment(A, C);
-        Angle ACB = new Angle(new LinkedList(Arrays.asList(A, B, C)));
+        Angle ACB = new Angle(new LinkedList(Arrays.asList(AC, BC)));
         HashSet<Fact> facts = new HashSet<>();
         facts.add(new ExistFact(new Triangle(new HashSet<>(Arrays.asList(AB, AC, BC)))));
         facts.add(new EqualityFact(ACB, Degree.createNumber(90)));
-        //facts.add(new EqualityFact(AB, new NumberEnveloper(4)));
-        //facts.add(new EqualityFact(AB, new NumberEnveloper(3)));
+        // facts.add(new EqualityFact(AB, new NumberEnveloper(4)));
+        // facts.add(new EqualityFact(AB, new NumberEnveloper(3)));
         Model model = new Model(facts);
         ExpertSystem.ForwardPass(model);
 

--- a/src/test/java/ExpertSystemTest.java
+++ b/src/test/java/ExpertSystemTest.java
@@ -1,3 +1,4 @@
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
@@ -5,6 +6,7 @@ import org.junit.Test;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.LinkedList;
+import java.util.stream.Collectors;
 
 import GeometryCore.ExpertSystem;
 import GeometryCore.Facts.BelongFact;
@@ -42,6 +44,29 @@ public class ExpertSystemTest{
                 ((Triangle)((ExistFact)x).object).lineSegments.contains(AB) &&
                 ((Triangle)((ExistFact)x).object).lineSegments.contains(BC) &&
                 ((Triangle)((ExistFact)x).object).lineSegments.contains(AC)));
+    }
+    @Test
+    public void RepeatingTriangleFactsTest() {
+        Vertex A = new Vertex();
+        Vertex B = new Vertex();
+        Vertex C = new Vertex();
+        LineSegment AB = new LineSegment(A, B);
+        LineSegment BC = new LineSegment(B, C);
+        LineSegment AC = new LineSegment(A, C);
+        HashSet<Fact> facts = new HashSet<>();
+        facts.add(new BelongFact(A, AB));
+        facts.add(new BelongFact(B, AB));
+        facts.add(new BelongFact(A, AC));
+        facts.add(new BelongFact(B, BC));
+        facts.add(new BelongFact(C, AC));
+        facts.add(new BelongFact(C, BC));
+        Model model = new Model(facts);
+        ExpertSystem.ForwardPass(model);
+
+        assertEquals(1, model.facts.stream().filter(x -> x instanceof ExistFact &&
+                ((Triangle) ((ExistFact) x).object).lineSegments.contains(AB) &&
+                ((Triangle) ((ExistFact) x).object).lineSegments.contains(BC) &&
+                ((Triangle) ((ExistFact) x).object).lineSegments.contains(AC)).collect(Collectors.toList()).size());
     }
 
     @Test


### PR DESCRIPTION
 Added deletion of repeating facts (but you have to override equality of geometrical objects that can be in multiple forms [like triangles: ABC, CBA, etc], otherwise it only deletes facts that have same links in subobjects)

